### PR TITLE
Rewrite deploy/ruckus.sh to use _get() and _post()

### DIFF
--- a/deploy/ruckus.sh
+++ b/deploy/ruckus.sh
@@ -149,8 +149,7 @@ _response_cookie() {
 _post_upload() {
   _post_action="$1"
   _post_file="$2"
-  _post_url="$3"
-
+  
   _post_boundary="----FormBoundary$(date "+%s%N")"
   
   _post_data="$({


### PR DESCRIPTION
Tested on ZoneDirector 10.5.1 and Unleashed 200.15.6, using `curl` and `wget` (`--use-wget`).

Please feel free to add yourself as an author.  
I assume you don't want to receive support requests, so I just included my info.