### PR TITLE
Remove awk usage & refuse host redirects

### DIFF
--- a/deploy/ruckus.sh
+++ b/deploy/ruckus.sh
@@ -74,8 +74,8 @@ ruckus_deploy() {
     _login_path=$(echo "$_login_url" | sed 's|https\?://[^/]\+||')
     if [ -z "$_login_path" ]; then
       # redirect was to a different host
-      _get "$_login_url" >/dev/null
-      _login_url="$(_response_header 'Location')"
+      _err "Connection failed: redirected to a different host. Configure Unleashed with a Preferred Master or Management Interface."
+      return 1
     fi
   fi
 
@@ -142,7 +142,7 @@ _response_header() {
 }
 
 _response_cookie() {
-  _response_header 'Set-Cookie' | awk -F';' '{for(i=1;i<=NF;i++) if (tolower($i) !~ /(path|domain|expires|max-age|secure|httponly|samesite)/) printf "%s; ", $i}' | sed 's/; $//'
+  _response_header 'Set-Cookie' | sed 's/;.*//'
 }
 
 _post_upload() {


### PR DESCRIPTION
I just got around to reading the acme.sh dev guidance, and see we [shouldn't use awk](https://github.com/acmesh-official/acme.sh/wiki/DNS-API-Dev-Guide#6-process-the-api-response).
I've removed the awk usage.

I also removed the login host-redirect handling: I think it's better to fail-fast if there's been an Unleashed Master election, and RUCKUS_HOST is now pointing to a member AP.